### PR TITLE
Prevents runtime error when writing to file

### DIFF
--- a/molecular_builder/core.py
+++ b/molecular_builder/core.py
@@ -310,7 +310,7 @@ def write(atoms, filename, bond_specs=None, atom_style="molecular", size=(640, 4
 
         pipeline = import_file(os.path.join(tmp_dir, "tmp.data"))
 
-        types = pipeline.source.data.particles.particle_types
+        types = pipeline.source.data.particles_.particle_types
         for symbol, i in symbols_dict.items():
             types.type_by_id(i).name = symbol
             types.type_by_id(i).load_defaults()


### PR DESCRIPTION
When using the latest version of OVITO (3.5.3) i get the following error when attempting to write a crystal to file:
`File "/Users/nick/Documents/github/molecular-builder/molecular_builder/core.py", line 315, in write
    types.type_by_id(i).name = symbol`
`RuntimeError: You tried to modify a ParticleType object that is currently shared by multiple owners. Please explicitly request a mutable version of the data object by using the '_' notation or by calling make_mutable() on the parent object. See the documentation of the DataObject.make_mutable() method for further information.`

This small change prevents the issue and was tested to run successfully using a selection of the provided examples.