### PR TITLE
Matrix geometry

### DIFF
--- a/molecular_builder/geometry.py
+++ b/molecular_builder/geometry.py
@@ -757,3 +757,128 @@ class NotchGeometry(Geometry):
         indicies = np.logical_not(np.logical_and(np.logical_not(is_inside1), np.logical_or(is_inside2, is_inside3)))
 
         return indicies
+
+
+class Matrix2DGeometry(Geometry):
+    """Carve out holes defined by a two-dimensional matrix. This can be useful
+    for instance when carving out a surface structure, but can also be used to
+    carve out holes inside a structure.
+
+    :param matrix: matrix defining which atoms to remove. Might be binary
+    :type matrix: ndarray
+    :param point: point in region
+    :type point: array_like
+    :param dir: direction of matrix normal vector. In the future this should be superseeded by giving the normal vector, but this requires support for angle.
+    :type dir: str
+    :param extentx: extent in x-direction. Spanning the entire structure by default
+    :type extentx: tuple, None
+    :param extenty: extent in y-direction. Spanning the entire structure by default
+    :type extenty: tuple, None
+    :param thickness: thickness of region that is carved out
+    :type thickness: float
+    :param dtype: matrix type
+    :type dtype: type
+    """
+    def __init__(self, matrix, point, dir="x", extentx=None, extenty=None,
+                 thickness=1, dtype=float):
+        assert len(matrix.shape) == 2, "Expected a matrix of exactly 2 dimensions"
+        self.matrix = np.asarray(matrix, dtype)
+        self.extentx, self.extenty = extentx, extenty
+        self.point = point
+        self.thickness = thickness
+        if dir == "x":
+            normal = [1, 0, 0]
+        elif dir == "y":
+            normal = [0, 1, 0]
+        elif dir == "z":
+            normal = [0, 0, 1]
+        self.normal = np.asarray(normal)
+
+    def __repr__(self):
+        return 'matrix-2d'
+
+    def __call__(self, atoms):
+        position = atoms.get_positions()
+        (k, l) = np.delete(range(3), np.argmax(self.normal))
+        if self.extentx is None:
+            maxx = np.max(position[:, k])
+            minx = np.min(position[:, k])
+            self.extentx = (maxx, minx)
+        if self.extenty is None:
+            maxy = np.max(position[:, l])
+            miny = np.min(position[:, l])
+            self.extenty = (maxy, miny)
+        # calculate distance from particles to the plane defined by
+        # the normal vector and the point
+        dist = self.distance_point_plane(self.normal, self.point, position)
+        # find the closest points on plane
+        point_plane = position + np.einsum('ij,k->jk', dist, self.normal)
+        # transform space coordinates onto structure surface
+        xs = point_plane[:, k]*(1-self.normal[k]**2)**(-1/2)
+        ys = point_plane[:, l]*(1-self.normal[l]**2)**(-1/2)
+        # find length of system, adding small tolerance to avoid index o.o.b.
+        tol = 1e-8
+        lenx = self.extentx[0] - self.extentx[1] + tol
+        leny = self.extenty[0] - self.extenty[1] + tol
+        # system length per matrix index
+        nlenx = lenx / self.matrix.shape[0]
+        nleny = leny / self.matrix.shape[1]
+        # link particles to matrix indices
+        indexx = np.int_(xs // nlenx)
+        indexy = np.int_(ys // nleny)
+        # evaluate matrix for all particles
+        values = self.matrix[np.ix_(indexx, indexy)]
+        # detect particles that should be removed
+        indices = np.all(dist < self.thickness * values, axis=0)
+        return indices
+
+
+
+
+class Matrix3DGeometry(Geometry):
+    """Carve out holes defined by a three-dimensional matrix. This can be useful
+    for instance when carving out a surface structure, but can also be used to
+    carve out holes inside a structure.
+
+    :param matrix: binary matrix defining which atoms to remove
+    :type matrix: ndarray
+    :param extentx: extent in x-direction. Spanning the entire structure by default
+    :type extentx: tuple, None
+    :param extenty: extent in y-direction. Spanning the entire structure by default
+    :type extenty: tuple, None
+    :param extentz: extent in z-direction. Spanning the entire structure by default
+    :type extentz: tuple, None
+    """
+    def __init__(self, matrix, extentx=None, extenty=None, extentz=None):
+        assert len(matrix.shape) == 3, "Expected a matrix of exactly 3 dimensions"
+        self.matrix = np.asarray(matrix, dtype=bool)
+        self.extentx, self.extenty, self.extentz = extentx, extenty, extentz
+
+    def __repr__(self):
+        return 'matrix-3d'
+
+    def __call__(self, atoms):
+        position = atoms.get_positions()
+        if self.extentx is None:
+            maxx = np.max(position[:, 0])
+            minx = np.min(position[:, 0])
+            self.extentx = (maxx, minx)
+        if self.extenty is None:
+            maxy = np.max(position[:, 1])
+            miny = np.min(position[:, 1])
+            self.extenty = (maxy, miny)
+        if self.extentz is None:
+            maxz = np.max(position[:, 2])
+            minz = np.min(position[:, 2])
+            self.extentz = (maxz, minz)
+
+
+if __name__ == "__main__":
+    from molecular_builder import create_bulk_crystal, carve_geometry
+
+    atoms = create_bulk_crystal("silicon_carbide_3c", (100, 100, 50))
+
+    matrix = np.asarray([[1, 0], [0, 1]], dtype=bool)
+    geometry = Matrix2DGeometry(matrix, point=95, thickness=10)
+
+    carve_geometry(atoms, geometry)

--- a/molecular_builder/geometry.py
+++ b/molecular_builder/geometry.py
@@ -759,7 +759,7 @@ class NotchGeometry(Geometry):
         return indicies
 
 
-class Matrix2DGeometry(Geometry):
+class MatrixGeometry(Geometry):
     """Carve out holes defined by a two-dimensional matrix. This can be useful
     for instance when carving out a surface structure, but can also be used to
     carve out holes inside a structure.
@@ -768,19 +768,19 @@ class Matrix2DGeometry(Geometry):
     :type matrix: ndarray
     :param point: point in region
     :type point: array_like
-    :param dir: direction of matrix normal vector. In the future this should be superseeded by giving the normal vector, but this requires support for angle.
+    :param dir: direction of matrix normal vector. In the future this should be replaced by the normal vector, but this requires support for angle.
     :type dir: str
-    :param extentx: extent in x-direction. Spanning the entire structure by default
+    :param extentx: extent in x-direction. Is rounded down to nearest matrix element. Spanning the entire structure by default
     :type extentx: tuple, None
-    :param extenty: extent in y-direction. Spanning the entire structure by default
+    :param extenty: extent in y-direction. Is rounded down to nearest matrix element. Spanning the entire structure by default
     :type extenty: tuple, None
     :param thickness: thickness of region that is carved out
     :type thickness: float
     :param dtype: matrix type
     :type dtype: type
     """
-    def __init__(self, matrix, point, dir="x", extentx=None, extenty=None,
-                 thickness=1, dtype=float):
+    def __init__(self, matrix, point, dir="z", extentx=None, extenty=None,
+                 thickness=1., dtype=float):
         assert len(matrix.shape) == 2, "Expected a matrix of exactly 2 dimensions"
         self.matrix = np.asarray(matrix, dtype)
         self.extentx, self.extenty = extentx, extenty
@@ -800,36 +800,48 @@ class Matrix2DGeometry(Geometry):
     def __call__(self, atoms):
         position = atoms.get_positions()
         (k, l) = np.delete(range(3), np.argmax(self.normal))
+        minx = np.min(position[:, k])
+        maxx = np.max(position[:, k])
+        miny = np.min(position[:, l])
+        maxy = np.max(position[:, l])
+        lx = maxx - minx
+        ly = maxy - miny
+        # let matrix span entire system if extent is not given
         if self.extentx is None:
-            maxx = np.max(position[:, k])
-            minx = np.min(position[:, k])
-            self.extentx = (maxx, minx)
+            self.extentx = (minx, maxx)
         if self.extenty is None:
-            maxy = np.max(position[:, l])
-            miny = np.min(position[:, l])
-            self.extenty = (maxy, miny)
+            self.extenty = (miny, maxy)
+        # find size of area to carve, adding small tolerance to avoid index o.o.b.
+        tol = 1e-8
+        lenx = self.extentx[1] - self.extentx[0] + tol
+        leny = self.extenty[1] - self.extenty[0] + tol
+        # system length per matrix index
+        dx = lenx / self.matrix.shape[0]
+        dy = leny / self.matrix.shape[1]
+        # init index
+        ixxmin = np.int_((self.extentx[0] - minx) // dx)
+        ixymin = np.int_((self.extenty[0] - miny) // dy)
+        nidxx = np.int_(lx//dx) + 1
+        nidxy = np.int_(ly//dy) + 1
+        # create potentially padded matrix
+        matrix_pad = np.zeros((nidxx, nidxy))
+        print(matrix_pad.shape)
+        matrix_pad[ixxmin:ixxmin+self.matrix.shape[0], ixymin:ixymin+self.matrix.shape[1]] = self.matrix
         # calculate distance from particles to the plane defined by
         # the normal vector and the point
         dist = self.distance_point_plane(self.normal, self.point, position)
-        # find the closest points on plane
-        point_plane = position + np.einsum('ij,k->jk', dist, self.normal)
+        # find the closest points on plane, 'dir'-direction might be wrong, but not important
+        point_plane = position + np.einsum('ij,k->ik', dist, self.normal)
         # transform space coordinates onto structure surface
-        xs = point_plane[:, k]*(1-self.normal[k]**2)**(-1/2)
-        ys = point_plane[:, l]*(1-self.normal[l]**2)**(-1/2)
-        # find length of system, adding small tolerance to avoid index o.o.b.
-        tol = 1e-8
-        lenx = self.extentx[0] - self.extentx[1] + tol
-        leny = self.extenty[0] - self.extenty[1] + tol
-        # system length per matrix index
-        nlenx = lenx / self.matrix.shape[0]
-        nleny = leny / self.matrix.shape[1]
+        xs = point_plane[:, k] - minx #*(1-self.normal[k]**2)**(-0.5) # commented out part is 1
+        ys = point_plane[:, l] - miny #*(1-self.normal[l]**2)**(-0.5) # when max(normal) == 1
         # link particles to matrix indices
-        indexx = np.int_(xs // nlenx)
-        indexy = np.int_(ys // nleny)
+        indexx = np.int_(xs // dx)
+        indexy = np.int_(ys // dy)
         # evaluate matrix for all particles
-        values = self.matrix[np.ix_(indexx, indexy)]
+        values = matrix_pad[(indexx, indexy)]
         # detect particles that should be removed
-        indices = np.all(dist < self.thickness * values, axis=0)
+        indices = dist.flat < self.thickness * np.array(values)
         return indices
 
 
@@ -860,25 +872,27 @@ class Matrix3DGeometry(Geometry):
     def __call__(self, atoms):
         position = atoms.get_positions()
         if self.extentx is None:
-            maxx = np.max(position[:, 0])
             minx = np.min(position[:, 0])
-            self.extentx = (maxx, minx)
+            maxx = np.max(position[:, 0])
+            self.extentx = (minx, maxx)
         if self.extenty is None:
-            maxy = np.max(position[:, 1])
             miny = np.min(position[:, 1])
-            self.extenty = (maxy, miny)
+            maxy = np.max(position[:, 1])
+            self.extenty = (miny, maxy)
         if self.extentz is None:
-            maxz = np.max(position[:, 2])
             minz = np.min(position[:, 2])
-            self.extentz = (maxz, minz)
+            maxz = np.max(position[:, 2])
+            self.extentz = (minz, maxz)
 
 
 if __name__ == "__main__":
     from molecular_builder import create_bulk_crystal, carve_geometry
 
-    atoms = create_bulk_crystal("silicon_carbide_3c", (100, 100, 50))
+    atoms = create_bulk_crystal("silicon_carbide_3c", (50, 50, 5))
 
-    matrix = np.asarray([[1, 0], [0, 1]], dtype=bool)
-    geometry = Matrix2DGeometry(matrix, point=95, thickness=10)
+    matrix = np.asarray([[1, 0, 0, 1], [0, 1, 1, 0], [1, 0, 0, 1]], dtype=bool)
+    matrix = np.ones((1000, 1000))
+    geometry = MatrixGeometry(matrix, point=5, thickness=4.05, extentx=(10, 40))
 
     carve_geometry(atoms, geometry)
+    atoms.write("atoms.data", format="lammps-data")


### PR DESCRIPTION
MatrixGeometry, a Molecular builder geometry that is defined by a NumPy 2d-array. This can be used to carve out any surface structure, for instance a structure inspired by Mount Rushmore or Mona Lisa. It can also be used to carve out other non-trivial, but more useful structures. In addition, non-trivial voids can be carved out using this geometry. The attached figures were generated with the code

```python
import numpy as np
import matplotlib.pylab as plt
from molecular_builder import create_bulk_crystal, carve_geometry
from molecular_builder.geometry import MatrixGeometry

def to_grayscale(im, weights = np.c_[0.2989, 0.5870, 0.1140]):
    """
    Transforms a colour image to a grayscale image by
    taking the mean of the RGB values, weighted
    by the matrix weights
    """
    tile = np.tile(weights, reps=(im.shape[0],im.shape[1],1))
    return np.sum(tile * im, axis=2)

original = plt.imread("mona_lisa.jpg")
grayscale = to_grayscale(original)

atoms = create_bulk_crystal("silicon_carbide_3c", (500, 500, 15))

geometry = MatrixGeometry(grayscale/10, point=5)

carve_geometry(atoms, geometry)
atoms.write("atoms.data", format="lammps-data")
```

![mount_rushmore](https://user-images.githubusercontent.com/31393910/153418280-2c1f1d45-4865-435a-92df-e1fae8be1116.png)
![mona_lisa](https://user-images.githubusercontent.com/31393910/153418314-410b6655-9bbd-4620-899b-8496052be8b6.png)
 